### PR TITLE
fix(issue-1): preload bg images to avoid white flash

### DIFF
--- a/script/myScript.js
+++ b/script/myScript.js
@@ -1,3 +1,13 @@
+// Preload the background images for light on and off
+const bgLightOff = new Image();
+bgLightOff.src = "./images/bgStage1.jpg";
+
+const bgLightOn = new Image();
+bgLightOn.src = "./images/bgStage2.jpg";
+
+
+
+
 //get the elements light toggle button, piano keys, text, and image
 const toggleButton = document.getElementById('toggleButton');
 const displayKey = document.getElementById("pianoKey");


### PR DESCRIPTION
Fixes #1

**What I did**
Preload bgStage1.jpg and bgStage2.jpg so background switches immediately without a white flash.

**How to test**
1. Open the app in an incognito window.
2. Click "Light On" — the background should switch instantly with no white flash.

Files changed:
- script/myScript.js (preload images)
