### PR TITLE
fix(issue-3): ensure keyboard presses show note label without prior m…

### DIFF
--- a/script/myScript.js
+++ b/script/myScript.js
@@ -54,6 +54,7 @@ document.addEventListener('keydown', function(event) {
     const keyNote = keyMap[boardkey];
 
     if (keyNote) {
+        event.preventDefault();
         playPiano(keyNote, "keydown");
     }
 });


### PR DESCRIPTION
Fixes #3

**What I Did:**  
The main issue described here is also resolved alongside the fix for Issue 2.  
I added `preventDefault();` to prevent unwanted default browser behaviors and ensure consistent note display.

**How to Test:**  
1. Pull this branch and serve the app locally (or check the Netlify/GitHub Pages preview).  
2. Press the keys on the keyboard repeatedly and observe whether the note label appears each time.  
3. Click on a piano key with the mouse, then start pressing keys on the keyboard, and verify that the same note label still appears consistently.

**Files Changed:**  
- script/myScript.js

**Priority:**  
Medium — affects user experience.
